### PR TITLE
Fix dark mode margin bug

### DIFF
--- a/css/tranquility.css
+++ b/css/tranquility.css
@@ -30,6 +30,7 @@ body.tranquility
   font-family:Univers,Scala,Georgia,Verdana,Times,Helvetica; 
   text-align:justify;
   line-height:140%;  
+   margin:0px;
 }
 
 div.tranquility_masker


### PR DESCRIPTION
When using a dark theme/background, tranquilizing a site leads to a really annoying white margin around the content. Adding margin=0px to the body CSS via Inspect Element fixes this temporarily - making it part of the body CSS should fix this in general.

![image](https://github.com/VivianWilde/tranquility-reader-webextensions/assets/45487680/e299b29e-7893-4517-a065-4044a670287e)
